### PR TITLE
Vilicht-Verbesserige

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ roeschti::roeschti! {
         funktion lis(&selber, schlüssel: Zeichecheti) -> Vilicht<&Zeichecheti>;
     }
 
-    statisch veränderbar DICTIONÄR: <Dico<Zeichecheti, Zeichecheti>> = Nüt;
+    statisch veränderbar DICTIONÄR: Vilicht<Dico<Zeichecheti, Zeichecheti>> = Nüt;
 
     struktur Konkret;
 

--- a/roesti_proc_macro/src/lib.rs
+++ b/roesti_proc_macro/src/lib.rs
@@ -11,7 +11,7 @@ fn replace_ident(ident: Ident) -> Option<TokenTree> {
         "Standard" => "Default",
         "Fähler" => "Error",
         "Vilicht" => "Option",
-        "Espaar" => "Some",
+        "Öppis" => "Some",
         "Nüt" => "None",
         "Resultat" => "Result",
         "Selber" => "Self",


### PR DESCRIPTION
Im Liesmich fehlt de Vilicht-Typ, und ich finde Vilicht::Espaar sött eigentli Vilicht::Öppis heisse